### PR TITLE
Correction + Optimisation fermer

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,16 +1,33 @@
-RegisterCommand("touches", function(source, args, rawCommand)
-
-	SetNuiFocus( true, true )
-	SendNUIMessage({
-		ativa = true
-	})
+local open = false
+RegisterCommand("touches", function()
+	if not open then
+		Touche()
+	else
+		Touche()
+		SendNUIMessage({
+			ativa = false
+		})
+	end
 end, false)
-
-
-RegisterNUICallback('fechar', function(data, cb)
-	SetNuiFocus( false )
-	SendNUIMessage({
-	ativa = false
-	})
-  	cb('ok')
-end)
+function Touche()
+	if open then
+		open = false
+		return
+	else
+		open = true
+		SendNUIMessage({
+			ativa = true
+		})
+		Citizen.CreateThread(function ()
+			while open do
+				Citizen.Wait(5.0)
+				if IsControlJustReleased(0, 178) then
+					Touche()
+					SendNUIMessage({
+						ativa = false
+					})
+				end
+			end
+		end)
+	end
+end

--- a/html/js/index.js
+++ b/html/js/index.js
@@ -1,9 +1,9 @@
 $(function() {
-  $(document).keyup(function(e) {
+  /*$(document).keyup(function(e) {
       if (e.keyCode == 27) {
           $.post('http://cst_menutouche/fechar', JSON.stringify({}));
       }
-  });
+  });*/
   $(document).ready(function() {
       window.addEventListener('message', function(event) {
           var item = event.data;

--- a/html/ui.html
+++ b/html/ui.html
@@ -26,7 +26,7 @@
                   <li>- Coffre : L</li>
                   <li>- Drift : SHIFT GAUCHE</li>
                 </ul>
-                <p>Echap pour quitter le menu</p>
+                <p>SUPPR pour quitter le menu</p>
             </div>
 		 </div>
 	  </div>


### PR DESCRIPTION
-0ms fermez
-passage de la touche pour fermer dans le client.lua. [SUPPR]
-Retirer fonction souris [Pour deplacer sont personnage meme discuter en pushtotalk tout en regardant le menu]

Personnellement je ne pouvais pas fermez le menu donc obliger de restart / stop la ressource pour qu'ils se ferment